### PR TITLE
Fix for error - parentheses

### DIFF
--- a/overcast_to_sqlite/cli.py
+++ b/overcast_to_sqlite/cli.py
@@ -29,7 +29,7 @@ from .utils import (
 )
 
 
-@click.group
+@click.group()
 @click.version_option()
 def cli() -> None:
     """Save listening history and feed/episode info from Overcast to SQLite."""


### PR DESCRIPTION
Was trying to solve this problem from scratch, found your package on pypi.org.  Tried to run it but repeatedly got the error:
"overcast_to_sqlite/cli.py", line 38, in <module> @cli.command() AttributeError: 'function' object has no attribute 'command'

in macOs terminal.

Line 32 in cli.py seems needs to be '@click.group()' not '@click.group' to avoid this error, not sure what I'm missing but wanted to make you aware, in case it's something that could be avoided for others with a 'how to use' line in the readme, if it's my mistake.

## Summary by Sourcery

Bug Fixes:
- Correct the `click.group` decorator to `click.group()` to resolve an AttributeError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Minor internal decorator adjustment in CLI configuration with no user-facing impact

<!-- end of auto-generated comment: release notes by coderabbit.ai -->