### PR TITLE
Limit episodes by days stored in database by env var

### DIFF
--- a/overcast_to_sqlite/cli.py
+++ b/overcast_to_sqlite/cli.py
@@ -116,6 +116,7 @@ def save(
         db.save_feed_and_episodes(feed, episodes)
 
     db.mark_feed_removed_if_missing(ingested_feed_ids)
+    db.cleanup_old_episodes()
 
 
 def _auth_and_fetch(auth_path: str, archive: Path | None) -> str:


### PR DESCRIPTION
### **User description**
1. Environment variable filtering in datastore.py:192-208: Modified save_feed_and_episodes() to filter out episodes where userUpdatedDate < (now - OVERCAST_LIMIT_DAYS) during insertion.
  2. Cleanup method in datastore.py:461-478: Added cleanup_old_episodes() method that deletes old episodes from the database, but only if there are more than 100 episode rows.
  3. CLI integration in cli.py:119: Added call to db.cleanup_old_episodes() at the end of the save command.

  How it works:
  - Set OVERCAST_LIMIT_DAYS=30 (or any number) to only keep episodes from the last 30 days
  - During save, episodes older than the limit won't be inserted
  - After save completes, if there are >100 episodes total, any remaining old episodes are deleted
  - If no environment variable is set, the behavior remains unchanged


___

### **PR Type**
Enhancement


___

### **Description**
- Add environment variable `OVERCAST_LIMIT_DAYS` to control episode retention

- Filter episodes during save to exclude old episodes

- Implement cleanup method to delete old episodes from database

- Integrate cleanup into CLI save command workflow


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Environment Variable OVERCAST_LIMIT_DAYS"] --> B["Filter Episodes During Save"]
  B --> C["Save Recent Episodes Only"]
  C --> D["Run Cleanup After Save"]
  D --> E["Delete Old Episodes if >100 Total"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.py</strong><dd><code>Integrate episode cleanup into save command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overcast_to_sqlite/cli.py

- Add call to `db.cleanup_old_episodes()` after feed processing


</details>


  </td>
  <td><a href="https://github.com/hbmartin/overcast-to-sqlite/pull/96/files#diff-4814cac7cd24236337d4aefd2b9b68e67cab449ca796f60fbca0bbce474a83ba">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>datastore.py</strong><dd><code>Implement episode filtering and cleanup functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

overcast_to_sqlite/datastore.py

<li>Add <code>os</code> import for environment variable access<br> <li> Filter episodes by <code>OVERCAST_LIMIT_DAYS</code> in <code>save_feed_and_episodes()</code><br> <li> Add <code>cleanup_old_episodes()</code> method to delete old episodes<br> <li> Only cleanup if more than 100 episodes exist


</details>


  </td>
  <td><a href="https://github.com/hbmartin/overcast-to-sqlite/pull/96/files#diff-10dbc9f923ef7984c39fec5ecaac817459c44fcb847db2820b143d1a00e7f5e2">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of old podcast episodes based on a configurable retention period.
  * Episodes older than the set number of days (using the `OVERCAST_LIMIT_DAYS` environment variable) are now removed if the total episode count exceeds 100.
  * Only recent episodes, as defined by the retention period, are saved during the import process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add environment variable `OVERCAST_LIMIT_DAYS` to limit stored episodes by age, with filtering and cleanup in `datastore.py` and CLI integration in `cli.py`.
> 
>   - **Behavior**:
>     - Add environment variable `OVERCAST_LIMIT_DAYS` to control episode retention.
>     - In `datastore.py`, `save_feed_and_episodes()` filters episodes older than the limit during insertion.
>     - `cleanup_old_episodes()` method deletes episodes older than the limit if more than 100 episodes exist.
>     - In `cli.py`, `db.cleanup_old_episodes()` is called at the end of the `save` command.
>   - **Functions**:
>     - `save_feed_and_episodes()` in `datastore.py` filters episodes by `OVERCAST_LIMIT_DAYS`.
>     - `cleanup_old_episodes()` in `datastore.py` deletes old episodes if total count exceeds 100.
>   - **CLI Integration**:
>     - `save()` in `cli.py` now includes a call to `cleanup_old_episodes()` after saving episodes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=hbmartin%2Fovercast-to-sqlite&utm_source=github&utm_medium=referral)<sup> for f7681065d58ff3d10e3f6864711b6cd2499e258a. You can [customize](https://app.ellipsis.dev/hbmartin/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->