### PR TITLE
patched datastore.py to skip cleanup when no query params exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ This displays total episodes played, total listening time, starred episodes, sub
 
 ## Searching
 
-The `search` command performs full-text search across episodes, feeds, and chapters. The `save` and `extend` commands must be run prior to this.
+The `search` command performs full-text search across episodes, feeds, and chapters. Run `save` and `extend` first, and run `chapters` as well if you want chapter results.
 
     $ overcast-to-sqlite search "machine learning"
 
-Results are grouped by category (episodes, feeds, chapters). Use `--limit` / `-l` to control the maximum results per category (default: 20).
+Results are grouped by category (episodes, feeds, chapters). Use `--limit` / `-l` to control the maximum results per category with a positive integer (default: 20).
 
     $ overcast-to-sqlite search "interview" -l 5
 
@@ -188,7 +188,7 @@ Results are grouped by category (episodes, feeds, chapters). Use `--limit` / `-l
 
 **feeds**: `overcastId`, `title`, `subscribed`, `overcastAddedDate`, `notifications`, `xmlUrl`, `htmlUrl`, `dateRemoveDetected`
 
-**episodes**: `overcastId`, `feedId` (FK to feeds), `title`, `url`, `overcastUrl`, `played`, `progress` (seconds), `enclosureUrl`, `userUpdatedDate`, `userRecommendedDate` (starred date), `pubDate`, `userDeleted`
+**episodes**: `overcastId`, `feedId`, `title`, `url`, `overcastUrl`, `played`, `progress` (seconds), `enclosureUrl`, `userUpdatedDate`, `userRecommendedDate` (starred date), `pubDate`, `userDeleted`
 
 **feeds_extended**: `xmlUrl` (FK to feeds), `title`, `description`, `lastUpdated`, `link`, `guid`, plus dynamic columns from RSS XML
 

--- a/overcast_to_sqlite/cli.py
+++ b/overcast_to_sqlite/cli.py
@@ -444,7 +444,7 @@ def stats(db_path: str) -> None:
     "-l",
     "--limit",
     default=20,
-    type=int,
+    type=click.IntRange(min=1),
     help="Maximum number of results per category",
 )
 def search(query: str, db_path: str, limit: int) -> None:

--- a/overcast_to_sqlite/datastore.py
+++ b/overcast_to_sqlite/datastore.py
@@ -50,6 +50,22 @@ from .constants import (
 )
 
 _DEFAULT_EPISODE_LIMIT = 100
+_PLAYED_WHERE_CLAUSE = f"played=1 OR {PROGRESS}>300"
+
+
+def _base_enclosure_url_sql(column_name: str) -> str:
+    """Return SQL that strips query parameters from an enclosure URL."""
+    return (
+        f"CASE WHEN instr({column_name}, '?') > 0 "
+        f"THEN substr({column_name}, 1, instr({column_name}, '?') - 1) "
+        f"ELSE {column_name} END"
+    )
+
+
+def _fts_phrase_query(query: str) -> str:
+    """Quote user input so FTS5 treats it as a literal phrase query."""
+    escaped_query = query.replace('"', '""')
+    return f'"{escaped_query}"'
 
 
 def _overcast_limit_days() -> int | None:
@@ -238,7 +254,20 @@ class Datastore:
                 >= cutoff_date
             ]
 
-        self._table(FEEDS).upsert(feed.to_dict(), pk=OVERCAST_ID)
+        feed_row = feed.to_dict()
+        if (
+            feed.htmlUrl is None
+            and (
+                existing_feed := self.db.execute(
+                    f"SELECT htmlUrl FROM {FEEDS} WHERE {OVERCAST_ID} = ?",
+                    [feed.overcastId],
+                ).fetchone()
+            )
+            is not None
+        ):
+            feed_row["htmlUrl"] = existing_feed[0]
+
+        self._table(FEEDS).upsert(feed_row, pk=OVERCAST_ID)
         self._table(EPISODES).upsert_all(
             [e.to_dict() for e in episodes],
             pk=OVERCAST_ID,
@@ -419,44 +448,59 @@ class Datastore:
 
     def _clean_enclosure_urls(self, *, deduplicate: bool = False) -> None:
         """Clean and normalize enclosure URLs by removing query parameters."""
+        self._normalize_enclosure_urls(EPISODES)
+
+        if not self._has_enclosure_url_query_parameters(EPISODES_EXTENDED):
+            return
+
+        if deduplicate:
+            self._deduplicate_extended_enclosure_urls()
+
+        self._normalize_enclosure_urls(EPISODES_EXTENDED)
+
+    def _has_enclosure_url_query_parameters(self, table_name: str) -> bool:
+        """Return whether a table has enclosure URLs with query parameters."""
+        return (
+            self.db.execute(
+                f"SELECT 1 FROM {table_name} "
+                f"WHERE instr({ENCLOSURE_URL}, '?') > 0 LIMIT 1",
+            ).fetchone()
+            is not None
+        )
+
+    def _normalize_enclosure_urls(self, table_name: str) -> None:
+        """Strip query parameters from enclosure URLs in the given table."""
+        if not self._has_enclosure_url_query_parameters(table_name):
+            return
+
+        update_clause = (
+            "UPDATE OR IGNORE" if table_name == EPISODES_EXTENDED else "UPDATE"
+        )
         self.db.execute(
-            f"UPDATE {EPISODES} "
+            f"{update_clause} {table_name} "
             f"SET {ENCLOSURE_URL} = "
             f"substr({ENCLOSURE_URL}, 1, instr({ENCLOSURE_URL}, '?') - 1) "
-            f"WHERE {ENCLOSURE_URL} LIKE '%?%'",
+            f"WHERE instr({ENCLOSURE_URL}, '?') > 0",
         )
         self._conn().commit()
 
-        if deduplicate:
-            self.db.execute(
-                f"""
-                DELETE FROM {EPISODES_EXTENDED} WHERE rowid IN (
-                    SELECT t1.rowid
-                    FROM {EPISODES_EXTENDED} t1
-                    JOIN (
-                        SELECT
-                            substr({ENCLOSURE_URL}, 1,
-                                   instr({ENCLOSURE_URL}, '?') - 1)
-                            AS base_url,
-                            MIN(rowid) AS min_rowid
-                        FROM {EPISODES_EXTENDED}
-                        WHERE {ENCLOSURE_URL} LIKE '%?%'
-                        GROUP BY base_url
-                    ) t2 ON
-                    substr(t1.{ENCLOSURE_URL}, 1,
-                           instr(t1.{ENCLOSURE_URL}, '?') - 1)
-                    = t2.base_url
-                    WHERE  t1.rowid > t2.min_rowid
-                )
-                """,
-            )
-            self._conn().commit()
-
+    def _deduplicate_extended_enclosure_urls(self) -> None:
+        """Delete duplicate extended episodes after enclosure URL normalization."""
+        enclosure_base_url = _base_enclosure_url_sql(ENCLOSURE_URL)
         self.db.execute(
-            f"UPDATE OR IGNORE {EPISODES_EXTENDED} "
-            f"SET {ENCLOSURE_URL} = "
-            f"substr({ENCLOSURE_URL}, 1, instr({ENCLOSURE_URL}, '?') - 1) "
-            f"WHERE {ENCLOSURE_URL} LIKE '%?%'",
+            f"""
+            WITH normalized AS (
+                SELECT rowid, {enclosure_base_url} AS base_url
+                FROM {EPISODES_EXTENDED}
+            ),
+            canonical AS (
+                SELECT MIN(rowid) AS keep_rowid
+                FROM normalized
+                GROUP BY base_url
+            )
+            DELETE FROM {EPISODES_EXTENDED}
+            WHERE rowid NOT IN (SELECT keep_rowid FROM canonical)
+            """,
         )
         self._conn().commit()
 
@@ -464,17 +508,21 @@ class Datastore:
         """Get the base field list for episode queries."""
         return [
             f"{EPISODES}.{TITLE}",
-            f"{EPISODES}.{URL}",
+            f"{EPISODES}.{URL} as episode_url",
             f"{FEEDS_EXTENDED}.{TITLE} as feed_title",
-            f"{FEEDS_EXTENDED}.'itunes:image:href' as image_",
-            f"{FEEDS_EXTENDED}.link as link_",
+            (
+                f"coalesce({EPISODES_EXTENDED}.'itunes:image:href', "
+                f"{FEEDS_EXTENDED}.'itunes:image:href') as image_"
+            ),
+            (
+                f"coalesce({EPISODES_EXTENDED}.link, {FEEDS_EXTENDED}.link, "
+                f"{EPISODES}.{URL}) as link_"
+            ),
             (
                 f"coalesce({EPISODES_EXTENDED}.description, "
                 f"'No description') as description"
             ),
             f"{EPISODES_EXTENDED}.pubDate as pubDate",
-            f"{EPISODES_EXTENDED}.'itunes:image:href' as 'images.'",
-            f"{EPISODES_EXTENDED}.link as 'links.'",
         ]
 
     def _build_episode_query(
@@ -523,7 +571,7 @@ class Datastore:
 
         query = self._build_episode_query(
             fields=fields,
-            where_clause="played=1 OR progress>300",
+            where_clause=_PLAYED_WHERE_CLAUSE,
             order_by=f"{USER_UPDATED_DATE} DESC",
         )
 
@@ -600,7 +648,7 @@ class Datastore:
     def get_listening_stats(self) -> dict[str, int]:
         """Get aggregate listening statistics."""
         played = self.db.execute(
-            f"SELECT COUNT(*) FROM {EPISODES} WHERE played=1",
+            f"SELECT COUNT(*) FROM {EPISODES} WHERE {_PLAYED_WHERE_CLAUSE}",
         ).fetchone()[0]
 
         total_progress = self.db.execute(
@@ -633,11 +681,14 @@ class Datastore:
         limit: int = 10,
     ) -> list[tuple[str, int]]:
         """Get top podcasts ranked by number of played episodes."""
+        if limit <= 0:
+            return []
+
         return self.db.execute(
             f"SELECT {FEEDS}.{TITLE}, COUNT(*) as count "
             f"FROM {EPISODES} "
             f"JOIN {FEEDS} ON {EPISODES}.{FEED_ID} = {FEEDS}.{OVERCAST_ID} "
-            f"WHERE played=1 "
+            f"WHERE {_PLAYED_WHERE_CLAUSE} "
             f"GROUP BY {EPISODES}.{FEED_ID} "
             f"ORDER BY count DESC LIMIT ?",
             [limit],
@@ -648,6 +699,9 @@ class Datastore:
         limit: int = 10,
     ) -> list[tuple[str, int]]:
         """Get top podcasts ranked by total listening time."""
+        if limit <= 0:
+            return []
+
         return self.db.execute(
             f"SELECT {FEEDS}.{TITLE}, "
             f"COALESCE(SUM({PROGRESS}), 0) as total_time "
@@ -665,8 +719,12 @@ class Datastore:
         self,
         query: str,
         limit: int = 20,
-    ) -> list[tuple[str, str]]:
+    ) -> list[tuple[str, str | None]]:
         """Search episodes using full-text search."""
+        if limit <= 0:
+            return []
+
+        fts_query = _fts_phrase_query(query)
         try:
             return self.db.execute(
                 f"SELECT ee.{TITLE}, fe.{TITLE} "
@@ -676,7 +734,7 @@ class Datastore:
                 f"ON ee.{FEED_XML_URL} = fe.{XML_URL} "
                 f"WHERE {EPISODES_EXTENDED}_fts MATCH ? "
                 f"ORDER BY fts.rank LIMIT ?",
-                [query, limit],
+                [fts_query, limit],
             ).fetchall()
         except sqlite3.OperationalError:
             return []
@@ -687,6 +745,10 @@ class Datastore:
         limit: int = 20,
     ) -> list[tuple[str]]:
         """Search feeds using full-text search."""
+        if limit <= 0:
+            return []
+
+        fts_query = _fts_phrase_query(query)
         try:
             return self.db.execute(
                 f"SELECT fe.{TITLE} "
@@ -694,7 +756,7 @@ class Datastore:
                 f"JOIN {FEEDS_EXTENDED} fe ON fe.rowid = fts.rowid "
                 f"WHERE {FEEDS_EXTENDED}_fts MATCH ? "
                 f"ORDER BY fts.rank LIMIT ?",
-                [query, limit],
+                [fts_query, limit],
             ).fetchall()
         except sqlite3.OperationalError:
             return []
@@ -705,6 +767,10 @@ class Datastore:
         limit: int = 20,
     ) -> list[tuple[str]]:
         """Search chapters using full-text search."""
+        if limit <= 0:
+            return []
+
+        fts_query = _fts_phrase_query(query)
         try:
             return self.db.execute(
                 f"SELECT ch.{CONTENT} "
@@ -712,7 +778,7 @@ class Datastore:
                 f"JOIN {CHAPTERS} ch ON ch.rowid = fts.rowid "
                 f"WHERE {CHAPTERS}_fts MATCH ? "
                 f"ORDER BY fts.rank LIMIT ?",
-                [query, limit],
+                [fts_query, limit],
             ).fetchall()
         except sqlite3.OperationalError:
             return []

--- a/overcast_to_sqlite/models.py
+++ b/overcast_to_sqlite/models.py
@@ -22,7 +22,7 @@ class Feed:
     subscribed: bool
     notifications: bool
     xmlUrl: str
-    htmlUrl: str
+    htmlUrl: str | None
     overcastAddedDate: str | None = None
 
     def to_dict(self) -> dict[str, Any]:

--- a/overcast_to_sqlite/overcast.py
+++ b/overcast_to_sqlite/overcast.py
@@ -117,7 +117,7 @@ def extract_feed_and_episodes_from_opml(
             subscribed=attribs.get("subscribed", "0") == "1",
             notifications=attribs.get("notifications", "0") == "1",
             xmlUrl=attribs[XML_URL],
-            htmlUrl=attribs.get("htmlUrl", ""),
+            htmlUrl=attribs.get("htmlUrl"),
             overcastAddedDate=_iso_date_or_none(
                 dict(attribs),
                 "overcastAddedDate",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ wheel-exclude = ["**/.mypy_cache", "**/.DS_Store"]
 
 [project]
 name = "overcast-to-sqlite"
-version = "1.0.0"
+version = "1.1.0"
 description = "Save listening history and feed/episode info from Overcast to a SQLite database."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,8 +45,7 @@ def test_stats_command_shows_listening_stats(tmp_path):
     )
 
     assert result.exit_code == 0
-    assert "Episodes played" in result.output
-    assert "3" in result.output
+    assert "Episodes played:      3" in result.output
     assert "Tech Podcast" in result.output
 
 
@@ -125,6 +124,53 @@ def test_search_command_with_extended_data(tmp_path):
 
     assert result.exit_code == 0
     assert "Episode 1" in result.output
+
+
+def test_search_command_quotes_punctuation_heavy_query(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+
+    store = Datastore(db_path)
+    store.save_extended_feed_and_episodes(
+        {
+            "xmlUrl": "https://example.com/feed.xml",
+            "title": "Tech Podcast",
+            "description": "Technology news and reviews",
+        },
+        [
+            {
+                "enclosureUrl": "https://cdn.example.com/1.mp3",
+                "feedXmlUrl": "https://example.com/feed.xml",
+                "title": "foo-bar",
+                "description": "Punctuation-heavy title",
+            },
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["search", "foo-bar", db_path],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "foo-bar" in result.output
+
+
+def test_search_command_rejects_non_positive_limit(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["search", "-l", "0", "foo", db_path],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 2
+    assert "0 is not in the range x>=1" in result.output
 
 
 def test_format_duration():

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -131,6 +131,21 @@ def test_get_listening_stats_starred(tmp_path):
     assert listening_stats["episodes_starred"] == 2
 
 
+def test_get_listening_stats_counts_progress_threshold(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(
+        _make_feed(),
+        [
+            _make_episode(overcast_id=1, played=False, progress=301),
+            _make_episode(overcast_id=2, played=False, progress=299),
+        ],
+    )
+
+    listening_stats = store.get_listening_stats()
+    assert listening_stats["episodes_played"] == 1
+
+
 def test_get_top_podcasts_by_episodes(tmp_path):
     db_path = str(tmp_path / "test.db")
     store = Datastore(db_path)
@@ -167,6 +182,21 @@ def test_get_top_podcasts_by_time(tmp_path):
     assert len(top) == 1
     assert top[0][0] == "Test Feed"
     assert top[0][1] == 10_800
+
+
+def test_get_top_podcasts_by_episodes_counts_progress_threshold(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(
+        _make_feed(title="Threshold Feed"),
+        [
+            _make_episode(overcast_id=1, played=False, progress=301),
+            _make_episode(overcast_id=2, played=False, progress=120),
+        ],
+    )
+
+    top = store.get_top_podcasts_by_episodes(limit=1)
+    assert top == [("Threshold Feed", 1)]
 
 
 def test_search_episodes_empty_db(tmp_path):
@@ -221,6 +251,30 @@ def test_search_episodes_with_data(tmp_path):
     assert results[0][0] == "Machine Learning Basics"
 
 
+def test_search_episodes_quotes_punctuation_heavy_query(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+
+    store.save_extended_feed_and_episodes(
+        {
+            "xmlUrl": "https://example.com/feed.xml",
+            "title": "Tech Podcast",
+            "description": "About technology",
+        },
+        [
+            {
+                "enclosureUrl": "https://cdn.example.com/1.mp3",
+                "feedXmlUrl": "https://example.com/feed.xml",
+                "title": "foo-bar",
+                "description": "Learn foo-bar fundamentals",
+            },
+        ],
+    )
+
+    results = store.search_episodes("foo-bar")
+    assert results == [("foo-bar", "Tech Podcast")]
+
+
 def test_search_feeds_with_data(tmp_path):
     db_path = str(tmp_path / "test.db")
     store = Datastore(db_path)
@@ -249,3 +303,183 @@ def test_get_listening_stats_empty_db(tmp_path):
     assert listening_stats["feeds_subscribed"] == 0
     assert listening_stats["feeds_removed"] == 0
     assert listening_stats["episodes_starred"] == 0
+
+
+def test_search_methods_return_empty_for_non_positive_limits(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+
+    assert store.get_top_podcasts_by_episodes(limit=0) == []
+    assert store.get_top_podcasts_by_time(limit=-1) == []
+    assert store.search_episodes("test", limit=0) == []
+    assert store.search_feeds("test", limit=-1) == []
+    assert store.search_chapters("test", limit=0) == []
+
+
+def test_get_recently_played_deduplicates_clean_and_query_param_urls(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(_make_feed(), [_make_episode(overcast_id=1)])
+    store.save_extended_feed_and_episodes(
+        {
+            "xmlUrl": "https://example.com/feed-1.xml",
+            "title": "Tech Podcast",
+            "description": "About technology",
+            "link": "https://example.com/feed-1",
+            "itunes:image:href": "https://example.com/feed-1.png",
+        },
+        [
+            {
+                "enclosureUrl": "https://cdn.example.com/1.mp3",
+                "feedXmlUrl": "https://example.com/feed-1.xml",
+                "title": "Episode 1",
+                "description": "Clean enclosure URL",
+                "link": "https://example.com/episodes/1",
+                "itunes:image:href": "https://example.com/episodes/1.png",
+                "pubDate": "Thu, 02 Jan 2025 00:00:00 GMT",
+            },
+            {
+                "enclosureUrl": "https://cdn.example.com/1.mp3?source=feed",
+                "feedXmlUrl": "https://example.com/feed-1.xml",
+                "title": "Episode 1 duplicate",
+                "description": "Duplicate enclosure URL with query params",
+                "link": "https://example.com/episodes/1-duplicate",
+                "itunes:image:href": "https://example.com/episodes/1-duplicate.png",
+                "pubDate": "Thu, 02 Jan 2025 00:00:00 GMT",
+            },
+        ],
+    )
+
+    results = store.get_recently_played()
+
+    with sqlite3.connect(db_path) as conn:
+        urls = conn.execute(
+            "SELECT enclosureUrl FROM episodes_extended ORDER BY rowid",
+        ).fetchall()
+
+    assert len(results) == 1
+    assert urls == [("https://cdn.example.com/1.mp3",)]
+
+
+def test_get_recently_played_normalizes_query_param_extended_url(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(_make_feed(), [_make_episode(overcast_id=1)])
+    store.save_extended_feed_and_episodes(
+        {
+            "xmlUrl": "https://example.com/feed-1.xml",
+            "title": "Tech Podcast",
+            "description": "About technology",
+            "link": "https://example.com/feed-1",
+            "itunes:image:href": "https://example.com/feed-1.png",
+        },
+        [
+            {
+                "enclosureUrl": "https://cdn.example.com/1.mp3?source=feed",
+                "feedXmlUrl": "https://example.com/feed-1.xml",
+                "title": "Episode 1",
+                "description": "Query parameter enclosure URL",
+                "link": "https://example.com/episodes/1",
+                "itunes:image:href": "https://example.com/episodes/1.png",
+                "pubDate": "Thu, 02 Jan 2025 00:00:00 GMT",
+            },
+        ],
+    )
+
+    results = store.get_recently_played()
+
+    with sqlite3.connect(db_path) as conn:
+        urls = conn.execute(
+            "SELECT enclosureUrl FROM episodes_extended ORDER BY rowid",
+        ).fetchall()
+
+    assert len(results) == 1
+    assert results[0]["episode_title"] == "Episode 1"
+    assert urls == [("https://cdn.example.com/1.mp3",)]
+
+
+def test_get_recently_played_falls_back_to_episode_url_for_missing_links(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(_make_feed(), [_make_episode(overcast_id=1)])
+    store.save_extended_feed_and_episodes(
+        {
+            "xmlUrl": "https://example.com/feed-1.xml",
+            "title": "Tech Podcast",
+            "description": "About technology",
+            "itunes:image:href": "https://example.com/feed-1.png",
+        },
+        [
+            {
+                "enclosureUrl": "https://cdn.example.com/1.mp3",
+                "feedXmlUrl": "https://example.com/feed-1.xml",
+                "title": "Episode 1",
+                "description": "Missing feed and episode links",
+                "itunes:image:href": "https://example.com/episodes/1.png",
+                "pubDate": "Thu, 02 Jan 2025 00:00:00 GMT",
+            },
+        ],
+    )
+
+    results = store.get_recently_played()
+
+    assert results[0]["link_"] == "https://example.com/1"
+
+
+def test_clean_enclosure_urls_skips_deduplication_without_query_params(
+    monkeypatch,
+    tmp_path,
+):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_extended_feed_and_episodes(
+        {
+            "xmlUrl": "https://example.com/feed-1.xml",
+            "title": "Tech Podcast",
+            "description": "About technology",
+        },
+        [
+            {
+                "enclosureUrl": "https://cdn.example.com/1.mp3",
+                "feedXmlUrl": "https://example.com/feed-1.xml",
+                "title": "Episode 1",
+                "description": "Clean enclosure URL",
+            },
+        ],
+    )
+
+    def fail_deduplicate() -> None:
+        msg = "Deduplication should be skipped when no query parameters exist"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(
+        store,
+        "_deduplicate_extended_enclosure_urls",
+        fail_deduplicate,
+    )
+
+    store._clean_enclosure_urls(deduplicate=True)  # noqa: SLF001
+
+
+def test_save_feed_and_episodes_preserves_existing_html_url_when_missing(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(_make_feed(), [])
+    store.save_feed_and_episodes(
+        Feed(
+            overcastId=1,
+            title="Test Feed",
+            subscribed=True,
+            notifications=False,
+            xmlUrl="https://example.com/feed-1.xml",
+            htmlUrl=None,
+        ),
+        [],
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        html_url = conn.execute(
+            "SELECT htmlUrl FROM feeds WHERE overcastId = 1",
+        ).fetchone()
+
+    assert html_url == ("https://example.com/1",)

--- a/tests/test_opml.py
+++ b/tests/test_opml.py
@@ -167,6 +167,30 @@ def test_unsubscribed_feed_parsed():
     assert feed.subscribed is False
 
 
+def test_feed_without_html_url_keeps_none():
+    root = ElementTree.fromstring(
+        """\
+        <opml version="2.0">
+          <body>
+            <outline text="feeds">
+              <outline
+                type="rss"
+                text="No HTML Feed"
+                title="No HTML Feed"
+                overcastId="303"
+                xmlUrl="https://example.com/no-html.xml"
+              />
+            </outline>
+          </body>
+        </opml>
+        """,
+    )
+
+    feeds = list(extract_feed_and_episodes_from_opml(root))
+    feed, _ = feeds[0]
+    assert feed.htmlUrl is None
+
+
 def test_playlist_to_dict():
     playlist = Playlist(
         title="Test",

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ wheels = [
 
 [[package]]
 name = "overcast-to-sqlite"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
and use a set-based CTE delete when cleanup is needed. Fixed a follow-on HTML issue in datastore.py so missing RSS link fields fall back to the episode URL.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/overcast-to-sqlite/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now handles punctuation-heavy queries more reliably and enforces a minimum search limit of 1.
  * Missing feed website links are now preserved as unavailable instead of being replaced with an empty value.

* **Bug Fixes**
  * Improved playback and stats calculations for episodes marked as played.
  * Search and recent-played results now better handle duplicate or URL-parameter variants.
  * Updated saved feed data to avoid overwriting existing website links when new data is incomplete.

* **Documentation**
  * Clarified the README search steps and refreshed table field notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->