### PR TITLE
Add audio download command for episode files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you simply want a page showing your recently listened episodes, try out the s
 - [Extending and saving full feeds](#extending-and-saving-full-feeds)
 - [Downloading transcripts](#downloading-transcripts)
 - [Downloading chapters](#downloading-chapters)
+- [Downloading audio files](#downloading-audio-files)
 - [Generating HTML pages](#generating-html-pages)
 - [Running all commands](#running-all-commands)
 - [Listening statistics](#listening-statistics)
@@ -46,6 +47,7 @@ Install it permanently if you want `overcast-to-sqlite` available for later comm
 | `extend` | Download XML feeds and extract all tags and attributes |
 | `transcripts` | Download available transcripts for episodes |
 | `chapters` | Download and store available chapters for episodes |
+| `audio` | Download episode audio files |
 | `html` | Generate HTML pages for played, starred, and deleted episodes |
 | `all` | Run save, extend, transcripts, and chapters sequentially |
 | `stats` | Show listening statistics |
@@ -131,6 +133,24 @@ The `chapters` command downloads and stores available chapters for episodes. The
 
 By default, chapters are archived to `archive/` adjacent to the database file. A different path can be set with the `-p`/`--path` flag.
 
+## Downloading audio files
+
+The `audio` command downloads the audio files for episodes in your Overcast history (played, queued, or starred). Only the `save` command MUST be run prior to this (`extend` is not required).
+
+    $ overcast-to-sqlite audio
+
+By default this will save audio files to `archive/audio/<feed title>/<episode title>.<ext>`.
+
+The download's location is then stored in the `enclosureDownloadPath` column of the `episodes` table, and re-running the command skips episodes that were already downloaded.
+
+A different path can be set with the `-p`/`--path` flag.
+
+There is also a `-s` flag to only download audio for starred episodes.
+
+It also supports the `-v` flag to print additional information.
+
+Note: audio files are large (often 50–200 MB per episode), so this command is intentionally not part of `all` and must be run explicitly.
+
 ## Generating HTML pages
 
 The `html` command generates static HTML pages for recently played, starred, and deleted episodes.
@@ -188,7 +208,7 @@ Results are grouped by category (episodes, feeds, chapters). Use `--limit` / `-l
 
 **feeds**: `overcastId`, `title`, `subscribed`, `overcastAddedDate`, `notifications`, `xmlUrl`, `htmlUrl`, `dateRemoveDetected`
 
-**episodes**: `overcastId`, `feedId`, `title`, `url`, `overcastUrl`, `played`, `progress` (seconds), `enclosureUrl`, `userUpdatedDate`, `userRecommendedDate` (starred date), `pubDate`, `userDeleted`
+**episodes**: `overcastId`, `feedId`, `title`, `url`, `overcastUrl`, `played`, `progress` (seconds), `enclosureUrl`, `userUpdatedDate`, `userRecommendedDate` (starred date), `pubDate`, `userDeleted`, `enclosureDownloadPath` (from `audio`)
 
 **feeds_extended**: `xmlUrl` (FK to feeds), `title`, `description`, `lastUpdated`, `link`, `guid`, plus dynamic columns from RSS XML
 

--- a/overcast_to_sqlite/cli.py
+++ b/overcast_to_sqlite/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 from concurrent.futures import ThreadPoolExecutor
+from mimetypes import guess_type
 from pathlib import Path
 from xml.etree import ElementTree
 
@@ -276,6 +277,91 @@ def transcripts(  # noqa: C901
             db.update_transcript_download_paths(
                 enclosure,
                 str(file_path),
+            )
+
+
+@cli.command()
+@click.argument(
+    "db_path",
+    type=click.Path(file_okay=True, dir_okay=False, allow_dash=False),
+    default="overcast.db",
+)
+@click.option(
+    "-p",
+    "--path",
+    "archive_path",
+    type=click.Path(file_okay=False, dir_okay=True, allow_dash=False),
+)
+@click.option("-s", "--starred-only", is_flag=True)
+@click.option("-v", "--verbose", is_flag=True)
+def audio(  # noqa: C901
+    db_path: str,
+    archive_path: str | None,
+    starred_only: bool,
+    verbose: bool,
+) -> None:
+    """Download episode audio files for all or starred episodes."""
+    db = Datastore(db_path)
+
+    audio_path = Path(archive_path) if archive_path else _archive_path(db_path, "audio")
+
+    audio_path.mkdir(parents=True, exist_ok=True)
+
+    db.ensure_episode_download_column()
+
+    audio_to_download = list(db.audio_to_download(starred_only=starred_only))
+
+    if verbose:
+        print(f"🔉Downloading {len(audio_to_download)} audio files...")
+
+    def _fetch_and_write_audio(
+        episode: tuple[int, str, str, str],
+    ) -> tuple[int, str] | None:
+
+        overcast_id, title, url, feed_title = episode
+        if verbose:
+            print(f"⬇️Downloading {title} @ {url}")
+        try:
+            response = requests.get(url, headers=_headers_ua(), stream=True, timeout=30)
+        except requests.exceptions.RequestException as e:
+            print(f"⛔ Error downloading {url}: {e}")
+            return None
+
+        if not response.ok:
+            print(f"⛔ Error code {response.status_code} downloading {url}")
+            if verbose:
+                print(response.headers)
+            return None
+        feed_path = audio_path / _sanitize_for_path(feed_title)
+        feed_path.mkdir(exist_ok=True)
+        fallback_type = guess_type(url)[0] or "audio/mpeg"
+        file_ext = _file_extension_for_type(response.headers, fallback_type)
+        file_path = feed_path / (_sanitize_for_path(title) + file_ext)
+        part_path = file_path.with_name(f"{file_path.name}.part")
+        if verbose:
+            print(f"📝Saving {file_path}")
+        try:
+            with part_path.open(mode="wb") as file:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    file.write(chunk)
+        except (requests.exceptions.RequestException, OSError) as e:
+            print(f"⛔ Error saving {url}: {e}")
+            part_path.unlink(missing_ok=True)
+            return None
+        part_path.replace(file_path)
+        return overcast_id, str(file_path.absolute())
+
+    with ThreadPoolExecutor(max_workers=BATCH_SIZE) as executor:
+        results = list(executor.map(_fetch_and_write_audio, audio_to_download))
+
+    if verbose:
+        print(f"Saving {len(results)} audio files to database")
+    for row in results:
+        if row is not None:
+            overcast_id, file_path = row
+            db.update_audio_download_path(
+                overcast_id=overcast_id,
+                audio_path=file_path,
             )
 
 

--- a/overcast_to_sqlite/datastore.py
+++ b/overcast_to_sqlite/datastore.py
@@ -19,6 +19,7 @@ from .constants import (
     CHAPTERS,
     CONTENT,
     DESCRIPTION,
+    ENCLOSURE_DL_PATH,
     ENCLOSURE_URL,
     EPISODES,
     EPISODES_EXTENDED,
@@ -390,6 +391,51 @@ class Datastore:
             enclosure,
             {TRANSCRIPT_DL_PATH: transcript_path},
         )
+
+    # AUDIO
+
+    def ensure_episode_download_column(self) -> bool:
+        """Ensure the enclosure download path column exists in episodes.
+
+        Returns bool indicating if the column was added.
+        """
+        try:
+            self.db.execute(f"SELECT {ENCLOSURE_DL_PATH} FROM {EPISODES} LIMIT 1")
+        except sqlite3.OperationalError:
+            self._table(EPISODES).add_column(ENCLOSURE_DL_PATH, str)
+            return True
+        return False
+
+    def audio_to_download(
+        self,
+        *,
+        starred_only: bool,
+    ) -> Iterable[tuple[int, str, str, str]]:
+        """Find episodes with audio enclosures to download.
+
+        Yields (overcast_id, title, enclosure_url, feed_title)
+        """
+        select = (
+            f"SELECT {EPISODES}.{OVERCAST_ID}, {EPISODES}.{TITLE}, "
+            f"{EPISODES}.{ENCLOSURE_URL}, {FEEDS}.{TITLE} FROM {EPISODES} "
+            f"LEFT JOIN {FEEDS} ON {EPISODES}.{FEED_ID} = {FEEDS}.{OVERCAST_ID} "
+        )
+        where = (
+            f"WHERE {ENCLOSURE_DL_PATH} IS NULL "
+            f"AND {EPISODES}.{ENCLOSURE_URL} IS NOT NULL"
+        )
+        order = f"ORDER BY {FEEDS}.{TITLE} ASC"
+        query = (
+            f"{select}{where} {order}"
+            if not starred_only
+            else f"{select}{where} AND {USER_REC_DATE} IS NOT NULL {order}"
+        )
+
+        yield from self.db.execute(query)
+
+    def update_audio_download_path(self, overcast_id: int, audio_path: str) -> None:
+        """Update episode with audio download path."""
+        self._table(EPISODES).update(overcast_id, {ENCLOSURE_DL_PATH: audio_path})
 
     # CHAPTERS
     def insert_chapters(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,174 @@
+import sqlite3
+
+from click.testing import CliRunner
+
+from overcast_to_sqlite import cli
+from overcast_to_sqlite.datastore import Datastore
+from overcast_to_sqlite.models import Episode, Feed
+
+
+def _populate_db(db_path: str) -> None:
+    store = Datastore(db_path)
+    feed = Feed(
+        overcastId=1,
+        title="Tech Podcast",
+        subscribed=True,
+        notifications=False,
+        xmlUrl="https://example.com/feed.xml",
+        htmlUrl="https://example.com",
+    )
+    episodes = [
+        Episode(
+            overcastId=i,
+            feedId=1,
+            title=f"Episode {i}",
+            url=f"https://example.com/{i}",
+            overcastUrl=f"https://overcast.fm/+{i}",
+            played=True,
+            userDeleted=False,
+            enclosureUrl=f"https://cdn.example.com/{i}.mp3",
+            progress=3600,
+            userUpdatedDate="2025-01-02T00:00:00+00:00",
+            userRecommendedDate="2025-01-03T00:00:00+00:00" if i == 2 else None,
+        )
+        for i in range(1, 4)
+    ]
+    store.save_feed_and_episodes(feed, episodes)
+
+
+def _mock_audio_urls(
+    requests_mock,
+    episode_ids: tuple[int, ...] = (1, 2, 3),
+    content_type: str = "audio/mpeg",
+) -> None:
+    for i in episode_ids:
+        requests_mock.get(
+            f"https://cdn.example.com/{i}.mp3",
+            content=f"audio {i}".encode(),
+            headers={"content-type": content_type},
+        )
+
+
+def _download_paths(db_path: str) -> dict[int, str | None]:
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT overcastId, enclosureDownloadPath FROM episodes",
+        ).fetchall()
+    return dict(rows)
+
+
+def test_audio_downloads_and_records_paths(tmp_path, requests_mock):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+    _mock_audio_urls(requests_mock)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["audio", db_path, "-p", str(tmp_path / "audio")],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    for i in range(1, 4):
+        file_path = tmp_path / "audio" / "Tech Podcast" / f"Episode {i}.mp3"
+        assert file_path.read_bytes() == f"audio {i}".encode()
+    assert not list((tmp_path / "audio").rglob("*.part"))
+    assert all(path is not None for path in _download_paths(db_path).values())
+
+
+def test_audio_starred_only(tmp_path, requests_mock):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+    _mock_audio_urls(requests_mock, episode_ids=(2,))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["audio", db_path, "-p", str(tmp_path / "audio"), "-s"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert requests_mock.call_count == 1
+    assert requests_mock.last_request.url == "https://cdn.example.com/2.mp3"
+    paths = _download_paths(db_path)
+    assert paths[2] is not None
+    assert paths[1] is None
+    assert paths[3] is None
+
+
+def test_audio_skips_already_downloaded(tmp_path, requests_mock):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+    store = Datastore(db_path)
+    store.ensure_episode_download_column()
+    store.update_audio_download_path(overcast_id=1, audio_path="/existing/1.mp3")
+    _mock_audio_urls(requests_mock, episode_ids=(2, 3))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["audio", db_path, "-p", str(tmp_path / "audio")],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    requested_urls = {request.url for request in requests_mock.request_history}
+    assert requested_urls == {
+        "https://cdn.example.com/2.mp3",
+        "https://cdn.example.com/3.mp3",
+    }
+    assert _download_paths(db_path)[1] == "/existing/1.mp3"
+
+
+def test_audio_http_error_skips_episode(tmp_path, requests_mock):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+    requests_mock.get("https://cdn.example.com/1.mp3", status_code=404)
+    _mock_audio_urls(requests_mock, episode_ids=(2, 3))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["audio", db_path, "-p", str(tmp_path / "audio")],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "⛔ Error code 404" in result.output
+    paths = _download_paths(db_path)
+    assert paths[1] is None
+    assert paths[2] is not None
+    assert paths[3] is not None
+
+
+def test_audio_default_path(tmp_path, requests_mock):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+    _mock_audio_urls(requests_mock)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.cli, ["audio", db_path], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    for i in range(1, 4):
+        file_path = tmp_path / "archive" / "audio" / "Tech Podcast" / f"Episode {i}.mp3"
+        assert file_path.exists()
+
+
+def test_audio_extension_falls_back_to_url_type(tmp_path, requests_mock):
+    db_path = str(tmp_path / "test.db")
+    _populate_db(db_path)
+    _mock_audio_urls(requests_mock, content_type="application/octet-stream")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["audio", db_path, "-p", str(tmp_path / "audio")],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    for i in range(1, 4):
+        assert (tmp_path / "audio" / "Tech Podcast" / f"Episode {i}.mp3").exists()

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -461,6 +461,68 @@ def test_clean_enclosure_urls_skips_deduplication_without_query_params(
     store._clean_enclosure_urls(deduplicate=True)  # noqa: SLF001
 
 
+def test_ensure_episode_download_column(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+
+    assert store.ensure_episode_download_column() is True
+    assert store.ensure_episode_download_column() is False
+
+    with sqlite3.connect(db_path) as conn:
+        columns = [row[1] for row in conn.execute("PRAGMA table_info(episodes)")]
+    assert "enclosureDownloadPath" in columns
+
+
+def test_audio_to_download_filters_recorded_and_null_enclosures(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(
+        _make_feed(),
+        [_make_episode(overcast_id=i) for i in range(1, 4)],
+    )
+    store.ensure_episode_download_column()
+    store.update_audio_download_path(overcast_id=2, audio_path="/audio/2.mp3")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE episodes SET enclosureUrl = NULL WHERE overcastId = 3")
+
+    rows = list(store.audio_to_download(starred_only=False))
+
+    assert rows == [(1, "Episode 1", "https://cdn.example.com/1.mp3", "Test Feed")]
+
+
+def test_audio_to_download_starred_only(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(
+        _make_feed(),
+        [
+            _make_episode(overcast_id=1),
+            _make_episode(overcast_id=2, starred=True),
+        ],
+    )
+    store.ensure_episode_download_column()
+
+    rows = list(store.audio_to_download(starred_only=True))
+
+    assert rows == [(2, "Episode 2", "https://cdn.example.com/2.mp3", "Test Feed")]
+
+
+def test_update_audio_download_path(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    store = Datastore(db_path)
+    store.save_feed_and_episodes(_make_feed(), [_make_episode(overcast_id=1)])
+    store.ensure_episode_download_column()
+
+    store.update_audio_download_path(overcast_id=1, audio_path="/audio/1.mp3")
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT enclosureDownloadPath FROM episodes WHERE overcastId = 1",
+        ).fetchone()
+    assert row == ("/audio/1.mp3",)
+    assert list(store.audio_to_download(starred_only=False)) == []
+
+
 def test_save_feed_and_episodes_preserves_existing_html_url_when_missing(tmp_path):
     db_path = str(tmp_path / "test.db")
     store = Datastore(db_path)


### PR DESCRIPTION
## Summary
Adds a new `audio` command to download episode audio files from Overcast and store their paths in the database. This allows users to archive their podcast episodes locally.

## Key Changes
- **New `audio` CLI command** (`overcast_to_sqlite/cli.py`):
  - Downloads audio files for all or starred episodes
  - Supports custom output path via `-p`/`--path` flag (defaults to `archive/audio/`)
  - Includes `-s`/`--starred-only` flag to download only starred episodes
  - Includes `-v`/`--verbose` flag for detailed logging
  - Uses thread pool for concurrent downloads (respects `BATCH_SIZE`)
  - Handles HTTP errors gracefully, skipping failed episodes
  - Uses `.part` files during download to prevent incomplete files
  - Determines file extension from Content-Type header with fallback to URL

- **Database schema updates** (`overcast_to_sqlite/datastore.py`):
  - `ensure_episode_download_column()`: Adds `enclosureDownloadPath` column to episodes table
  - `audio_to_download()`: Queries episodes with audio enclosures that haven't been downloaded yet
  - `update_audio_download_path()`: Records downloaded file paths in the database

- **Comprehensive test coverage** (`tests/test_audio.py`):
  - Tests successful downloads and path recording
  - Tests starred-only filtering
  - Tests skipping already-downloaded episodes
  - Tests HTTP error handling
  - Tests default path behavior
  - Tests Content-Type fallback for file extensions

- **Documentation** (`README.md`):
  - Added `audio` command to command reference table
  - Added "Downloading audio files" section with usage examples and notes
  - Updated episodes table schema documentation

## Implementation Details
- Audio files are organized by feed title: `archive/audio/<feed title>/<episode title>.<ext>`
- Downloads are atomic: files are written to `.part` files and renamed only after successful completion
- Already-downloaded episodes are skipped on subsequent runs (checked via `enclosureDownloadPath` column)
- Concurrent downloads use `ThreadPoolExecutor` with configurable worker count
- Content-Type header is used to determine file extension; falls back to URL-based detection
- The command is intentionally not included in the `all` command due to large file sizes (50-200 MB per episode)

https://claude.ai/code/session_0131d1xVU4ssPgZoBU71BFry

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/overcast-to-sqlite/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

